### PR TITLE
Expose container block I/O counters in stats (utilization.disk_io)

### DIFF
--- a/environment/docker/stats.go
+++ b/environment/docker/stats.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"math"
+	"strings"
 	"time"
 
 	"emperror.dev/errors"
@@ -88,6 +89,17 @@ func (e *Environment) pollResources(ctx context.Context) error {
 			for _, nw := range v.Networks {
 				st.Network.RxBytes += nw.RxBytes
 				st.Network.TxBytes += nw.TxBytes
+			}
+
+			// Docker surfaces cgroup block I/O counters through the blkio
+			// recursive list on both cgroup v1 ("Read"/"Write") and v2
+			// ("read"/"write" from io.stat), so match the op case-insensitively.
+			for _, bio := range v.BlkioStats.IoServiceBytesRecursive {
+				if strings.EqualFold(bio.Op, "read") {
+					st.DiskIo.ReadBytes += bio.Value
+				} else if strings.EqualFold(bio.Op, "write") {
+					st.DiskIo.WriteBytes += bio.Value
+				}
 			}
 
 			e.Events().Publish(environment.ResourceEvent, st)

--- a/environment/stats.go
+++ b/environment/stats.go
@@ -20,6 +20,11 @@ type Stats struct {
 	// Current network transmit in & out for a container.
 	Network NetworkStats `json:"network"`
 
+	// Cumulative disk I/O for the container (blkio / cgroup io.stat). Values
+	// are counters since container start; clients derive throughput from
+	// deltas between readings, the same as the network counters.
+	DiskIo DiskIoStats `json:"disk_io"`
+
 	// The current uptime of the container, in milliseconds.
 	Uptime int64 `json:"uptime"`
 }
@@ -27,4 +32,9 @@ type Stats struct {
 type NetworkStats struct {
 	RxBytes uint64 `json:"rx_bytes"`
 	TxBytes uint64 `json:"tx_bytes"`
+}
+
+type DiskIoStats struct {
+	ReadBytes  uint64 `json:"read_bytes"`
+	WriteBytes uint64 `json:"write_bytes"`
 }

--- a/server/resources.go
+++ b/server/resources.go
@@ -68,4 +68,6 @@ func (ru *ResourceUsage) Reset() {
 	ru.Uptime = 0
 	ru.Network.TxBytes = 0
 	ru.Network.RxBytes = 0
+	ru.DiskIo.ReadBytes = 0
+	ru.DiskIo.WriteBytes = 0
 }


### PR DESCRIPTION
## What

Adds cumulative container block-I/O counters to the stats payload:

```json
"utilization": {
  "network": { "rx_bytes": 27353515, "tx_bytes": 132234063 },
  "disk_io": { "read_bytes": 0, "write_bytes": 81649664 }
}
```

## Why

Docker's stats stream (which `pollResources` already consumes) carries the cgroup block-I/O counters, but wings currently drops them. Surfacing them lets panels and API consumers show per-server disk throughput exactly the way they already derive network rates — deltas between readings of a cumulative counter. Disk I/O is often the first thing saturating a node packed with game servers (world autosaves, chunk generation, steamcmd updates), and today there's no per-server visibility into it.

## How

+24 lines, additive only — mirrors the existing `NetworkStats` shape:

- `environment/stats.go`: new `DiskIoStats{read_bytes, write_bytes}` on `Stats` as `disk_io`
- `environment/docker/stats.go`: sum `BlkioStats.IoServiceBytesRecursive` into it; ops matched case-insensitively since cgroup v1 reports `Read`/`Write` while v2 (io.stat) reports `read`/`write`
- `server/resources.go`: zero the counters in `Reset()`

Existing consumers are unaffected (unknown JSON fields are ignored by the panel).

## Testing

Running in production on a live node (built from v1.0.0-beta26 + this patch, cgroup v2, Docker 28). Counters verified against real workloads: a forced Palworld world save moved `write_bytes` by ~47 MB in one reading; steamcmd install traffic and zero-read steady state (fully page-cached world) both report as expected. Websocket `stats` events carry the field as well since they serialize the same struct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cumulative disk I/O metrics to resource usage data, including read and write byte totals.

* **Bug Fixes**
  * Disk I/O counters now reset correctly when resource usage is reset, preventing stale values from carrying over.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->