### PR TITLE
fix: fixed log rotation not using the wrapper

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -468,7 +468,7 @@ func initLogging() {
 	} else if config.Get().Quiet {
 		log.SetLevel(log.WarnLevel)
 	}
-	log.SetHandler(multi.New(cli.Default, cli.New(w.File, false)))
+	log.SetHandler(multi.New(cli.Default, cli.New(w, false)))
 	log.WithField("path", p).Info("writing log files to disk")
 }
 


### PR DESCRIPTION
Changed the logger to use the rotation-aware handler instead of the file descriptor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI logging by ensuring log output is written through the configured rotating log handler.
  * Helps preserve expected log rotation behavior during command-line use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->