### PR TITLE
Rename pelican-dev org references to pelican

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,4 +12,4 @@
 # This should make it easy to add new rules without breaking existing ones.
 
 # Global
-* @pelican-dev/wings
+* @pelican/wings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,13 +34,13 @@
 
 ## v1.11.5
 ### Added
-* Added a config option to disable Wings config.yml updates from the Panel (https://github.com/pelican-dev/wings/commit/ec6d6d83ea3eb14995c24f001233e85b37ffb87b)
+* Added a config option to disable Wings config.yml updates from the Panel (https://github.com/pelican/wings/commit/ec6d6d83ea3eb14995c24f001233e85b37ffb87b)
 
 ### Changed
 * Wings is now built with Go 1.19.7
 
 ### Fixed
-* Fixed archives containing partially matched file names (https://github.com/pelican-dev/wings/commit/43b3496f0001cec231c80af1f9a9b3417d04e8d4)
+* Fixed archives containing partially matched file names (https://github.com/pelican/wings/commit/43b3496f0001cec231c80af1f9a9b3417d04e8d4)
 
 ## v1.11.4
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ dependencies, and allowing users to authenticate with the same credentials they 
 
 ## Reporting Issues
 
-Feel free to report any wings specific issues or feature requests in [GitHub Issues](https://github.com/pelican-dev/wings/issues/new).
+Feel free to report any wings specific issues or feature requests in [GitHub Issues](https://github.com/pelican/wings/issues/new).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,13 +3,13 @@
 ## Supported Versions
 
 While Pelican is in beta, we only provide security fixes for the most recent beta release. Older beta releases are unsupported.  
-![](https://img.shields.io/github/v/release/pelican-dev/wings?label=latest-release)
+![](https://img.shields.io/github/v/release/pelican/wings?label=latest-release)
 
 ## Reporting a Vulnerability
 
 Please report any vulnerabilities via _one_ of the following methods:
 
-- [Create a security advisory on GitHub](https://github.com/pelican-dev/wings/security/advisories/new)
+- [Create a security advisory on GitHub](https://github.com/pelican/wings/security/advisories/new)
 - Send an e-mail to <team@pelican.dev>
 
 Include steps to reproduce, affected versions, impact, and a proof of concept if available.

--- a/cmd/selfupdate.go
+++ b/cmd/selfupdate.go
@@ -29,7 +29,7 @@ func newSelfupdateCommand() *cobra.Command {
 		Run:   selfupdateCmdRun,
 	}
 
-	command.Flags().StringVar(&updateArgs.repoOwner, "repo-owner", "pelican-dev", "GitHub repository owner")
+	command.Flags().StringVar(&updateArgs.repoOwner, "repo-owner", "pelican", "GitHub repository owner")
 	command.Flags().StringVar(&updateArgs.repoName, "repo-name", "wings", "GitHub repository name")
 	command.Flags().BoolVar(&updateArgs.force, "force", false, "Force update even if on latest version")
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,6 +1,6 @@
 services:
   wings:
-    image: ghcr.io/pelican-dev/wings:latest
+    image: ghcr.io/pelican/wings:latest
     restart: always
     networks:
       - wings0


### PR DESCRIPTION
**Do not merge this yet.** This is the half that genuinely has to wait, unlike #209.

The module path rename moved out into #209, which is safe to land whenever, so what's left here is just the six lines that are live values pointing at a place that doesn't exist yet. Based on #209 for now so the diff only shows the remainder; it'll retarget itself to main once that one goes in.

The one worth actually looking at is `cmd/selfupdate.go`, where `--repo-owner` defaults to `pelican-dev`. That's the value self-update uses to go looking for releases, and it's baked into binaries that are already out in the wild, so a fresh checkout doesn't help anybody who already has wings installed.

The rest is the CODEOWNERS team, the image in `docker-compose.example.yml`, and links in the README, SECURITY and CHANGELOG.

Two things that can't be done from a PR and still need doing separately: recreate the `@pelican/wings` team so CODEOWNERS resolves again, and republish the wings image under `ghcr.io/pelican/wings`.
