### PR TITLE
Finish the wings org rename (the part #208 missed)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,4 +12,4 @@
 # This should make it easy to add new rules without breaking existing ones.
 
 # Global
-* @pelican-dev/wings
+* @pelican/wings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,13 +34,13 @@
 
 ## v1.11.5
 ### Added
-* Added a config option to disable Wings config.yml updates from the Panel (https://github.com/pelican-dev/wings/commit/ec6d6d83ea3eb14995c24f001233e85b37ffb87b)
+* Added a config option to disable Wings config.yml updates from the Panel (https://github.com/pelican/wings/commit/ec6d6d83ea3eb14995c24f001233e85b37ffb87b)
 
 ### Changed
 * Wings is now built with Go 1.19.7
 
 ### Fixed
-* Fixed archives containing partially matched file names (https://github.com/pelican-dev/wings/commit/43b3496f0001cec231c80af1f9a9b3417d04e8d4)
+* Fixed archives containing partially matched file names (https://github.com/pelican/wings/commit/43b3496f0001cec231c80af1f9a9b3417d04e8d4)
 
 ## v1.11.4
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ dependencies, and allowing users to authenticate with the same credentials they 
 
 ## Reporting Issues
 
-Feel free to report any wings specific issues or feature requests in [GitHub Issues](https://github.com/pelican-dev/wings/issues/new).
+Feel free to report any wings specific issues or feature requests in [GitHub Issues](https://github.com/pelican/wings/issues/new).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,13 +3,13 @@
 ## Supported Versions
 
 While Pelican is in beta, we only provide security fixes for the most recent beta release. Older beta releases are unsupported.  
-![](https://img.shields.io/github/v/release/pelican-dev/wings?label=latest-release)
+![](https://img.shields.io/github/v/release/pelican/wings?label=latest-release)
 
 ## Reporting a Vulnerability
 
 Please report any vulnerabilities via _one_ of the following methods:
 
-- [Create a security advisory on GitHub](https://github.com/pelican-dev/wings/security/advisories/new)
+- [Create a security advisory on GitHub](https://github.com/pelican/wings/security/advisories/new)
 - Send an e-mail to <team@pelican.dev>
 
 Include steps to reproduce, affected versions, impact, and a proof of concept if available.

--- a/cmd/selfupdate.go
+++ b/cmd/selfupdate.go
@@ -29,7 +29,7 @@ func newSelfupdateCommand() *cobra.Command {
 		Run:   selfupdateCmdRun,
 	}
 
-	command.Flags().StringVar(&updateArgs.repoOwner, "repo-owner", "pelican-dev", "GitHub repository owner")
+	command.Flags().StringVar(&updateArgs.repoOwner, "repo-owner", "pelican", "GitHub repository owner")
 	command.Flags().StringVar(&updateArgs.repoName, "repo-name", "wings", "GitHub repository name")
 	command.Flags().BoolVar(&updateArgs.force, "force", false, "Force update even if on latest version")
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,6 +1,6 @@
 services:
   wings:
-    image: ghcr.io/pelican-dev/wings:latest
+    image: ghcr.io/pelican/wings:latest
     restart: always
     networks:
       - wings0


### PR DESCRIPTION
#208 never actually reached main. It was based on `chore/wings-module-path` while that was still open, and because that branch didn't get deleted after #209 merged, GitHub left the base alone and #208 merged into the branch instead of into main. So the module rename landed and these six lines didn't.

This is the same content, retargeted at main. Nothing new in it.

The one that matters is `cmd/selfupdate.go`, where `--repo-owner` is still `pelican-dev` — that's what self-update uses to look for releases. The rest is the CODEOWNERS team, the image in `docker-compose.example.yml`, and links in the README, SECURITY and CHANGELOG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated repository links and ownership references to the current project location.
  * Updated security advisory, issue reporting, and release documentation links.
  * Self-update now uses the current project location by default.
  * Updated the example container image reference to the current registry path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->